### PR TITLE
Fix unexisting github maintainer account ref

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @adbeda @agcopenhaver @int3l @mxr-conda @oblute @rluria14
+* @adbedada @agcopenhaver @int3l @mxr-conda @oblute @rluria14

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
-* [@adbeda](https://github.com/adbeda/)
+* [@adbedada](https://github.com/adbedada/)
 * [@agcopenhaver](https://github.com/agcopenhaver/)
 * [@int3l](https://github.com/int3l/)
 * [@mxr-conda](https://github.com/mxr-conda/)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,7 +62,7 @@ about:
 extra:
   recipe-maintainers:
     - mxr-conda
-    - adbeda
+    - adbedada
     - agcopenhaver
     - int3l
     - oblute


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
